### PR TITLE
fix: 🐛 added native linux assets for SkiaSharp

### DIFF
--- a/restapi/Program.cs
+++ b/restapi/Program.cs
@@ -74,11 +74,11 @@ builder.Services.AddAzureClients(clientBuilder =>
 */
 var app = builder.Build();
 
-if (builder.Environment.IsDevelopment())
-{
+//if (builder.Environment.IsDevelopment())
+//{
   app.UseSwagger();
   app.UseSwaggerUI();
-}
+//}
 
 app.UseResponseCompression();
 app.UseCors("anydomain");

--- a/restapi/restapi.csproj
+++ b/restapi/restapi.csproj
@@ -27,6 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SkiaSharp" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.5" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />


### PR DESCRIPTION
- added package SkiaSharp.NativeAssets.Linux to restapi.
without this package SkiaSharp wont run on in the azure app service server.